### PR TITLE
Incorporate tests: Add tests for password and encryption functions

### DIFF
--- a/task/encrypt.go
+++ b/task/encrypt.go
@@ -4,121 +4,81 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
 	"fmt"
 	"io"
 	"log"
 	"os"
-	"syscall"
-
-	"golang.org/x/term"
 )
 
-// PasswordReader returns password read from a reader
-type PasswordReader interface {
-	ReadPassword() ([]byte, error)
+type DataEncrypt interface {
+	Encrypt(data []byte, key []byte) ([]byte, error)
+	Decrypt(data []byte, key []byte) ([]byte, error)
 }
 
-// StdInPasswordReader represents an stdin password reader
-type StdinPasswordReader struct {
+type DB struct {
 }
 
-/*
-   ReadPassword for StdinPasswordReader reads the
-   password from stdin by using the term package's
-   ReadPassword function which prompts for user input.
-*/
-func (pr StdinPasswordReader) ReadPassword() ([]byte, error) {
-	password, err := term.ReadPassword(syscall.Stdin)
-	return password, err
-}
-
-/*
-   initPassReader assigns the password returned by the passed
-   PasswordReader to the corresponding variables and then
-   returns them.
-*/
-func initPassReader(pr PasswordReader) ([]byte, error) {
-	password, err := pr.ReadPassword()
-	if err != nil {
-		return nil, err
-	}
-	return password, nil
-}
-
-/*
-   ReadPassword receives the inputed user password from initPassReader.
-   It accepts a bool var that informs the function if this is a new
-   database. If true then the user is prompted to confirm the previously
-   given password. If the confirmation fails an error is returned.
-
-   Implementation details:
-   - initPassReader will call whichever ReadPassword method was passed
-     to it altering how the password is fetched. However, the validity
-     checks of the given password should be contained in this function.
-*/
-func ReadPassword(newDb bool, pr PasswordReader) (password []byte, err error) {
-	fmt.Printf("Enter Password: ")
-	password, err = initPassReader(pr)
+func (db DB) Encrypt(data []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}
 
-	if newDb == true {
-		fmt.Printf("\nConfirm Password: ")
-		confirmPass, err := initPassReader(pr)
-		if err != nil {
-			return nil, err
-		}
-
-		if string(password) != string(confirmPass) {
-			return nil, fmt.Errorf("\nPasswords did not match! Please try again.")
-
-		}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
 	}
 
-	return password, err
+	// gcm.NonceSize returns the size of the nonce that must be
+	// passed to Seal.
+	// Never use more than 2^32 random nonces with a given key.
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	encryptedData := gcm.Seal(nonce, nonce, data, nil)
+
+	return encryptedData, err
 }
 
-/*
-   hashPassword returns a byte slice of the sha256 hash created from
-   the password inputed by the user.
+func (db DB) Decrypt(encryptedData []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
 
-   Implementation details:
-   - It does not salt the password, it just returns the sha256 equivalent hash.
-*/
-func hashPassword(password []byte) []byte {
-	initHash := sha256.Sum256(password)
-	hash := initHash[:]
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
 
-	return hash
+	// The nonce value is stored at the beginning of the
+	// encrypted file.
+	nonce := encryptedData[:gcm.NonceSize()]
+	encryptedData = encryptedData[gcm.NonceSize():]
+
+	data, err := gcm.Open(nil, nonce, encryptedData, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, err
 }
 
-/*
-   regPassword calls hashPassword and writes the returned key into a a file.
-   It uses SetPaths to get the path where the key is stored.
+func wrapDataEncrypt(db DataEncrypt, action string, data []byte, key []byte) ([]byte, error) {
+	var err error
 
-   Implementation details:
-   - Permissions are set so that only the user can read/write the key file.
-*/
-func regPassword(newDb bool) {
-	var path Path = *SetPaths()
-	pr := StdinPasswordReader{}
-
-	password, err := ReadPassword(newDb, pr)
-	if err != nil {
-		log.Fatal(err)
-	} else if password == nil {
-		err = fmt.Errorf("\nPassword cannot be blank!\n")
-		log.Fatal(err)
+	if action == "encrypt" {
+		data, err = db.Encrypt(data, key)
+	} else if action == "decrypt" {
+		data, err = db.Decrypt(data, key)
+	} else {
+		data = nil
+		err = fmt.Errorf("\nUnknown encryption action choice!\n")
 	}
 
-	key := hashPassword(password)
-
-	err = os.WriteFile(path.key, key, 0600)
-	if err != nil {
-		log.Fatal(err)
-	}
+	return data, err
 }
 
 /*
@@ -136,6 +96,7 @@ func regPassword(newDb bool) {
 */
 func dbEncrypt() {
 	var path Path = *SetPaths()
+	db := DB{}
 	defer func() {
 		if p := recover(); p != nil {
 			fmt.Printf("Encryption Error: %v", p)
@@ -152,25 +113,13 @@ func dbEncrypt() {
 		log.Panic(err)
 	}
 
-	block, err := aes.NewCipher(key)
+	encryptedData, err := wrapDataEncrypt(db, "encrypt", data, key)
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
+	} else if encryptedData == nil {
+		err = fmt.Errorf("\nEncrypted data is nil. Encryption failed!\n")
+		log.Fatal(err)
 	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	// gcm.NonceSize returns the size of the nonce that must be
-	// passed to Seal.
-	// Never use more than 2^32 random nonces with a given key.
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		log.Panic(err)
-	}
-
-	encryptedData := gcm.Seal(nonce, nonce, data, nil)
 
 	err = os.WriteFile(path.db, encryptedData, 0644)
 	if err != nil {
@@ -196,6 +145,7 @@ func dbEncrypt() {
 */
 func dbDecrypt() {
 	var path Path = *SetPaths()
+	db := DB{}
 	defer func() {
 		if p := recover(); p != nil {
 			os.Remove(path.key)
@@ -208,9 +158,6 @@ func dbDecrypt() {
 		log.Panic(err)
 	}
 
-	decSuccess := true
-	var data []byte
-
 	key, err := os.ReadFile(path.key)
 	if os.IsNotExist(err) {
 		newDB := false
@@ -220,32 +167,13 @@ func dbDecrypt() {
 		log.Panic(err)
 	}
 
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	// The nonce value is stored at the beginning of the
-	// encrypted file.
-	nonce := encryptedData[:gcm.NonceSize()]
-	encryptedData = encryptedData[gcm.NonceSize():]
-
-	data, err = gcm.Open(nil, nonce, encryptedData, nil)
-	if err != nil {
-		decSuccess = false
-	}
-
-	if decSuccess == true {
+	data, err := wrapDataEncrypt(db, "decrypt", encryptedData, key)
+	if err == nil {
 		err = os.WriteFile(path.db, data, 0644)
 		if err != nil {
 			log.Panic(err)
 		}
-	} else if decSuccess == false {
+	} else if err != nil {
 		os.Remove(path.key)
 		log.Fatal("\nDecryption error!\n")
 	}

--- a/task/encrypt.go
+++ b/task/encrypt.go
@@ -89,12 +89,12 @@ func wrapDataEncrypt(db DataEncrypt, action string, data []byte, key []byte) ([]
    Galois Counter Mode with the standard nonce length is returned.
    After a nonce is created with the proper length, the data is
    encrypted by calling Seal and written back to the filesystem
-   at the path provided by path.db.
+   at the path provided by path.DB.
 
    Implementation details:
    - Should be called with defer in each function that interacts with the db.
 */
-func dbEncrypt() {
+func DbEncrypt() {
 	var path Path = *SetPaths()
 	db := DB{}
 	defer func() {
@@ -103,12 +103,12 @@ func dbEncrypt() {
 		}
 	}()
 
-	data, err := os.ReadFile(path.db)
+	data, err := os.ReadFile(path.DB)
 	if err != nil {
 		log.Panic(err)
 	}
 
-	key, err := os.ReadFile(path.key)
+	key, err := os.ReadFile(path.KEY)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -121,7 +121,7 @@ func dbEncrypt() {
 		log.Fatal(err)
 	}
 
-	err = os.WriteFile(path.db, encryptedData, 0644)
+	err = os.WriteFile(path.DB, encryptedData, 0644)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -143,38 +143,38 @@ func dbEncrypt() {
    Implementation details:
    - TODO: Add details
 */
-func dbDecrypt() {
+func DbDecrypt() {
 	var path Path = *SetPaths()
 	db := DB{}
 	defer func() {
 		if p := recover(); p != nil {
-			os.Remove(path.key)
+			os.Remove(path.KEY)
 			fmt.Printf("Decryption Error: %v", p)
 		}
 	}()
 
-	encryptedData, err := os.ReadFile(path.db)
+	encryptedData, err := os.ReadFile(path.DB)
 	if err != nil {
 		log.Panic(err)
 	}
 
-	key, err := os.ReadFile(path.key)
+	key, err := os.ReadFile(path.KEY)
 	if os.IsNotExist(err) {
 		newDB := false
 		regPassword(newDB)
-		key, err = os.ReadFile(path.key)
+		key, err = os.ReadFile(path.KEY)
 	} else if err != nil {
 		log.Panic(err)
 	}
 
 	data, err := wrapDataEncrypt(db, "decrypt", encryptedData, key)
 	if err == nil {
-		err = os.WriteFile(path.db, data, 0644)
+		err = os.WriteFile(path.DB, data, 0644)
 		if err != nil {
 			log.Panic(err)
 		}
 	} else if err != nil {
-		os.Remove(path.key)
+		os.Remove(path.KEY)
 		log.Fatal("\nDecryption error!\n")
 	}
 }

--- a/task/password.go
+++ b/task/password.go
@@ -1,0 +1,118 @@
+package task
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+// PasswordReader returns password read from a reader
+type PasswordReader interface {
+	ReadPassword() ([]byte, error)
+}
+
+// StdInPasswordReader represents an stdin password reader
+type StdinPasswordReader struct {
+}
+
+/*
+   ReadPassword for StdinPasswordReader reads the
+   password from stdin by using the term package's
+   ReadPassword function which prompts for user input.
+*/
+func (pr StdinPasswordReader) ReadPassword() ([]byte, error) {
+	password, err := term.ReadPassword(syscall.Stdin)
+	return password, err
+}
+
+/*
+   wrapPasswordReader assigns the password returned by the passed
+   PasswordReader to the corresponding variables and then
+   returns them.
+*/
+func wrapPasswordReader(pr PasswordReader) ([]byte, error) {
+	password, err := pr.ReadPassword()
+	if err != nil {
+		return nil, err
+	}
+	return password, nil
+}
+
+/*
+   ReadPassword receives the inputed user password from wrapPasswordReader.
+   It accepts a bool var that informs the function if this is a new
+   database. If true then the user is prompted to confirm the previously
+   given password. If the confirmation fails an error is returned.
+
+   Implementation details:
+   - wrapPasswordReader will call whichever ReadPassword method was passed
+     to it altering how the password is fetched. However, the validity
+     checks of the given password should be contained in this function.
+*/
+func ReadPassword(newDb bool, pr PasswordReader) (password []byte, err error) {
+	fmt.Printf("Enter Password: ")
+	password, err = wrapPasswordReader(pr)
+	if err != nil {
+		return nil, err
+	}
+
+	if newDb == true {
+		fmt.Printf("\nConfirm Password: ")
+		confirmPass, err := wrapPasswordReader(pr)
+		if err != nil {
+			return nil, err
+		}
+
+		if string(password) != string(confirmPass) {
+			return nil, fmt.Errorf("\nPasswords did not match! Please try again.")
+
+		}
+	}
+
+	return password, err
+}
+
+/*
+   hashPassword returns a byte slice of the sha256 hash created from
+   the password inputed by the user.
+
+   Implementation details:
+   - It does not salt the password, it just returns the sha256 equivalent hash.
+*/
+func hashPassword(password []byte) []byte {
+	initHash := sha256.Sum256(password)
+	hash := initHash[:]
+
+	return hash
+}
+
+/*
+   regPassword calls hashPassword and writes the returned key into a a file.
+   It uses SetPaths to get the path where the key is stored.
+
+   Implementation details:
+   - Permissions are set so that only the user can read/write the key file.
+*/
+func regPassword(newDb bool) {
+	var path Path = *SetPaths()
+	pr := StdinPasswordReader{}
+
+	password, err := ReadPassword(newDb, pr)
+	if err != nil {
+		log.Fatal(err)
+	} else if password == nil {
+		err = fmt.Errorf("\nPassword cannot be blank!\n")
+		log.Fatal(err)
+	}
+
+	key := hashPassword(password)
+
+	err = os.WriteFile(path.key, key, 0600)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/task/password.go
+++ b/task/password.go
@@ -77,13 +77,13 @@ func ReadPassword(newDb bool, pr PasswordReader) (password []byte, err error) {
 }
 
 /*
-   hashPassword returns a byte slice of the sha256 hash created from
+   HashPassword returns a byte slice of the sha256 hash created from
    the password inputed by the user.
 
    Implementation details:
    - It does not salt the password, it just returns the sha256 equivalent hash.
 */
-func hashPassword(password []byte) []byte {
+func HashPassword(password []byte) []byte {
 	initHash := sha256.Sum256(password)
 	hash := initHash[:]
 
@@ -91,7 +91,7 @@ func hashPassword(password []byte) []byte {
 }
 
 /*
-   regPassword calls hashPassword and writes the returned key into a a file.
+   regPassword calls HashPassword and writes the returned key into a a file.
    It uses SetPaths to get the path where the key is stored.
 
    Implementation details:
@@ -109,9 +109,9 @@ func regPassword(newDb bool) {
 		log.Fatal(err)
 	}
 
-	key := hashPassword(password)
+	key := HashPassword(password)
 
-	err = os.WriteFile(path.key, key, 0600)
+	err = os.WriteFile(path.KEY, key, 0600)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/task/task.go
+++ b/task/task.go
@@ -3,11 +3,12 @@ package task
 import (
 	"encoding/binary"
 	"fmt"
-	bolt "go.etcd.io/bbolt"
 	"log"
 	"math"
 	"os"
 	"strconv"
+
+	bolt "go.etcd.io/bbolt"
 )
 
 type Path struct {
@@ -89,6 +90,7 @@ func dbOpen() (db *bolt.DB) {
 	} else if os.IsNotExist(err) {
 		newDb := true
 		regPassword(newDb)
+		fmt.Printf("\nA new task db has been created!\n")
 	}
 
 	db, err := bolt.Open(path.db, 0644, nil)

--- a/task/task.go
+++ b/task/task.go
@@ -12,8 +12,8 @@ import (
 )
 
 type Path struct {
-	db  string
-	key string
+	DB  string
+	KEY string
 }
 
 /*
@@ -29,7 +29,7 @@ func SetPaths() (path *Path) {
 	defer func() {
 		if p := recover(); p != nil {
 			fmt.Printf("Path Error: %v\n", p)
-			path = &Path{db: "~/.tasks.db", key: "~/.tasksdbkey"}
+			path = &Path{DB: "~/.tasks.db", KEY: "~/.tasksdbkey"}
 		}
 	}()
 
@@ -45,7 +45,7 @@ func SetPaths() (path *Path) {
 	}
 
 	key := "/dev/shm/.taskdb"
-	return &Path{db: db, key: key}
+	return &Path{DB: db, KEY: key}
 }
 
 /*
@@ -85,15 +85,15 @@ func dbOpen() (db *bolt.DB) {
 		}
 	}()
 
-	if _, err := os.Stat(path.db); err == nil {
-		dbDecrypt()
+	if _, err := os.Stat(path.DB); err == nil {
+		DbDecrypt()
 	} else if os.IsNotExist(err) {
 		newDb := true
 		regPassword(newDb)
 		fmt.Printf("\nA new task db has been created!\n")
 	}
 
-	db, err := bolt.Open(path.db, 0644, nil)
+	db, err := bolt.Open(path.DB, 0644, nil)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -118,7 +118,7 @@ func dbOpen() (db *bolt.DB) {
 */
 func AddTask(task string) {
 	db := dbOpen()
-	defer dbEncrypt()
+	defer DbEncrypt()
 	defer db.Close()
 	defer func() {
 		if p := recover(); p != nil {
@@ -168,7 +168,7 @@ func AddTask(task string) {
 */
 func ListTasks() {
 	db := dbOpen()
-	defer dbEncrypt()
+	defer DbEncrypt()
 	defer db.Close()
 	defer func() {
 		if p := recover(); p != nil {
@@ -212,7 +212,7 @@ func ListTasks() {
 */
 func DeleteTask(taskNum string) {
 	db := dbOpen()
-	defer dbEncrypt()
+	defer DbEncrypt()
 	defer db.Close()
 	defer func() {
 		if p := recover(); p != nil {

--- a/task/task.go
+++ b/task/task.go
@@ -68,7 +68,9 @@ func itob(val int) []byte {
    to read only. It returns a pointer to a DB type.
 
    Implementation details:
-   - TODO: talk about error handling
+   - In case of recovery a pointer to a DB type is still returned
+     in order for db.Close() (deferred in the other functions) to
+     work.
 */
 func dbOpen() (db *bolt.DB) {
 	var path Path = *SetPaths()

--- a/test/encrypt_test.go
+++ b/test/encrypt_test.go
@@ -1,0 +1,39 @@
+package tasktest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dgiampouris/taskcli/task"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	var path task.Path = *task.SetPaths()
+	password := []byte("password")
+	originData := []byte("data")
+
+	_ = os.Rename(path.DB, path.DB+".bak")
+	_ = os.Rename(path.KEY, path.KEY+".bak")
+
+	_ = os.Remove(path.DB)
+	_ = os.Remove(path.KEY)
+
+	key := task.HashPassword(password)
+	_ = os.WriteFile(path.KEY, key, 0600)
+	_ = os.WriteFile(path.DB, originData, 0644)
+
+	task.DbEncrypt()
+	encData, _ := os.ReadFile(path.DB)
+	assert.NotEqual(t, originData, encData)
+
+	task.DbDecrypt()
+	decData, _ := os.ReadFile(path.DB)
+	assert.Equal(t, originData, decData)
+
+	os.Remove(path.DB)
+	os.Remove(path.KEY)
+
+	_ = os.Rename(path.DB+".bak", path.DB)
+	_ = os.Rename(path.KEY+".bak", path.KEY)
+}

--- a/test/encrypt_test.go
+++ b/test/encrypt_test.go
@@ -8,6 +8,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+/*
+   TestEncryptDecrypt test if the encryption and decryption functions
+   have the desired effect to the file that is being encrypted or
+   decrypted. Initially a mock password and data are defined. The
+   original key and db is backed up and then the mock data are
+   encrypted and decrypted with the mock key. If the resulting
+   data is the same after the whole process, then the encryption
+   process is successful.
+
+   Implementation details:
+   - It is also checked if the encrypted data is different than
+     the original data, to make sure that the encryption indeed
+     took place.
+*/
 func TestEncryptDecrypt(t *testing.T) {
 	var path task.Path = *task.SetPaths()
 	password := []byte("password")

--- a/test/password_test.go
+++ b/test/password_test.go
@@ -8,11 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// stubPasswordReader is a mock implementation of StdinPasswordReader
 type stubPasswordReader struct {
 	Password    []byte
 	ReturnError bool
 }
 
+/*
+   ReadPassword is a mock implementation of the equivalent
+   StdinPasswordReader method.
+*/
 func (pr stubPasswordReader) ReadPassword() ([]byte, error) {
 	if pr.ReturnError {
 		return nil, errors.New("stubbed error")
@@ -20,6 +25,7 @@ func (pr stubPasswordReader) ReadPassword() ([]byte, error) {
 	return pr.Password, nil
 }
 
+// TestReadPasswordReturnError tests if ReadPassword returns an error
 func TestReadPasswordReturnError(t *testing.T) {
 	newDb := false
 	pr := stubPasswordReader{ReturnError: true}
@@ -29,6 +35,10 @@ func TestReadPasswordReturnError(t *testing.T) {
 	assert.Equal(t, []byte(nil), result)
 }
 
+/*
+   TestReadPassword tests if the password returned from ReadPassword
+   is the same as the inputed one.
+*/
 func TestReadPassword(t *testing.T) {
 	newDb := false
 	pr := stubPasswordReader{Password: []byte("password")}

--- a/test/password_test.go
+++ b/test/password_test.go
@@ -1,0 +1,38 @@
+package tasktest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dgiampouris/taskcli/task"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubPasswordReader struct {
+	Password    []byte
+	ReturnError bool
+}
+
+func (pr stubPasswordReader) ReadPassword() ([]byte, error) {
+	if pr.ReturnError {
+		return nil, errors.New("stubbed error")
+	}
+	return pr.Password, nil
+}
+
+func TestReadPasswordReturnError(t *testing.T) {
+	newDb := false
+	pr := stubPasswordReader{ReturnError: true}
+	result, err := task.ReadPassword(newDb, pr)
+	assert.Error(t, err)
+	assert.Equal(t, errors.New("stubbed error"), err)
+	assert.Equal(t, []byte(nil), result)
+}
+
+func TestReadPassword(t *testing.T) {
+	newDb := false
+	pr := stubPasswordReader{Password: []byte("password")}
+	result, err := task.ReadPassword(newDb, pr)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("password"), result)
+}


### PR DESCRIPTION
The code is now more modular to allow for testing and easier expansion in general. Additionally, the password functionality is in a separate file than the encryption functionality.
`ReadPassword` as well as `DbEncrypt` and `DbDecrypt` are now accompanied by their respective tests.